### PR TITLE
disable search hit for the day if any schedule on product

### DIFF
--- a/app/Http/Controllers/Khufu/SchedulesController.php
+++ b/app/Http/Controllers/Khufu/SchedulesController.php
@@ -30,16 +30,18 @@ class SchedulesController extends Controller
         // Format dateTimes
         $formattedStartAt = Carbon::parse($start_at);
         $formattedEndAt = Carbon::parse($end_at);
+        $formattedStartOfDay = Carbon::parse($start_at)->startOfDay();
+        $formattedEndOfDat = Carbon::parse($end_at)->endOfDay();
 
 
         // get booked product_ids
-        $bookedProducts = Schedule::where(function ($query) use ($formattedStartAt, $formattedEndAt) {
-            $query->whereBetween('start_at', [$formattedStartAt, $formattedEndAt])
-                ->orWhereBetween('end_at', [$formattedStartAt, $formattedEndAt]);
+        $bookedProducts = Schedule::where(function ($query) use ($formattedStartOfDay, $formattedEndOfDat) {
+            $query->whereBetween('start_at', [$formattedStartOfDay, $formattedEndOfDat])
+                ->orWhereBetween('end_at', [$formattedStartOfDay, $formattedEndOfDat]);
         })
-            ->orWhere(function ($query) use ($formattedStartAt, $formattedEndAt) {
-                $query->where('start_at', '<', $formattedStartAt)
-                    ->where('end_at', '>', $formattedEndAt);
+            ->orWhere(function ($query) use ($formattedStartOfDay, $formattedEndOfDat) {
+                $query->where('start_at', '<', $formattedStartOfDay)
+                    ->where('end_at', '>', $formattedEndOfDat);
             })
             ->pluck('product_id')->toArray();
 


### PR DESCRIPTION
disable search hit for the day if any schedule on the product, regardless of time differences between search time and scheduled time on the day.
同日中の貸し出し予定があれば、たとえ検索時刻と既存予約時刻が重ならなくとも、その日いっぱい予約検索にはヒットさせない